### PR TITLE
Updated README to clarify default action, not functions as an override, and to clarify default delimiter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # `gcr.io/paketo-buildpacks/environment-variables`
+
 The Paketo Environment Variables Buildpack is a Cloud Native Buildpack that embeds environment variables into an image.
 
 ## Behavior
+
 This buildpack will participate all the following conditions are met
 
 * Any environment variable matching `$BPE_*` is set
@@ -11,16 +13,20 @@ The buildpack will do the following:
 * Modify the launch environment using the `$BPE_*` envrionment variables, as described in the Configuration section below
 
 ## Configuration
-| Environment Variable | Description
-|----------------------|------------
-|`$BPE_<NAME>` | prepend value to `$NAME`, delimiting with OS path list separator
-|`$BPE_APPEND_<NAME>` | append value to `$NAME`
-|`$BPE_DEFAULT_<NAME>` | set default value for `$NAME`
-|`$BPE_DELIM_<NAME>` | set delimeter to use when appending or prepending to $NAME
-|`$BPE_OVERRIDE_<NAME>` | set `$NAME` to value
-|`$BPE_PREPEND_<NAME>` | prepend value to `$NAME`
+
+| Environment Variable   | Description                                                |
+| ---------------------- | ---------------------------------------------------------- |
+| `$BPE_<NAME>`          | set `$NAME` to value (same as override)                    |
+| `$BPE_APPEND_<NAME>`   | append value to `$NAME`                                    |
+| `$BPE_DEFAULT_<NAME>`  | set default value for `$NAME`                              |
+| `$BPE_DELIM_<NAME>`    | set delimeter to use when appending or prepending to $NAME |
+| `$BPE_OVERRIDE_<NAME>` | set `$NAME` to value                                       |
+| `$BPE_PREPEND_<NAME>`  | prepend value to `$NAME`                                   |
+
+The default delimiter is an empty string, i.e. there is no default delimiter.
 
 ## License
+
 This buildpack is released under version 2.0 of the [Apache License][a].
 
 [a]: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION

## Summary

The behavior of default (i.e. no action set) has changed.

## Use Cases

The default behavior when an action is not set should match up with [the spec](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules), which says when there is no suffix present, the behavior is to override.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [n/a] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
