### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/environment-variables`
 
-The Paketo Environment Variables Buildpack is a Cloud Native Buildpack that embeds environment variables into an image.
+The Paketo Buildpack for Environment Variables is a Cloud Native Buildpack that embeds environment variables into an image.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/environment-variables"
   id = "paketo-buildpacks/environment-variables"
   keywords = ["environment-variables", "configuration"]
-  name = "Paketo Environment Variables Buildpack"
+  name = "Paketo Buildpack for Environment Variables"
   version = "{{.version}}"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
 


### PR DESCRIPTION
Renames 'Paketo Environment Variables Buildpack' to 'Paketo Buildpack for Environment Variables'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
